### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2236,7 +2236,7 @@ function onEndDrawing(e) {
 
                     // Função para obter o valor de um parâmetro da URL
                     function getParameterByName(name, url = window.location.href) {
-                        name = name.replace(/[\[\]]/g, "\\$&");
+                        name = name.replace(/\\/g, "\\\\").replace(/[\[\]]/g, "\\$&");
                         let regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
                             results = regex.exec(url);
                         if (!results) return null;


### PR DESCRIPTION
Fixes [https://github.com/Jonny-Marcos/PlanMilT/security/code-scanning/2](https://github.com/Jonny-Marcos/PlanMilT/security/code-scanning/2)

To fix the problem, we need to ensure that backslashes in the `name` parameter are properly escaped before using it in a regular expression. This can be achieved by adding a step to escape backslashes in the `name` parameter before replacing other special characters. We will use a regular expression to replace all occurrences of backslashes with double backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
